### PR TITLE
Added copyright holder/year meta to dist.ini.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,8 @@ author  = Olaf Alders (current maintainer)
 license = Perl_5
 version = 0.0945
 main_module = lib/Archive/Any.pm
+copyright_holder = Michael G Schwern, Clint Moore, Olaf Alders
+copyright_year   = 2016
 
 [GatherDir]
 exclude_filename = cpanfile


### PR DESCRIPTION
Hi @oalders 

Please review the PR.
I noticed when I tried to build the dist, I got the following error:

       [DZ] beginning to build Archive-Any
       no copyright holder specified at /usr/local/share/perl/5.18.2/Dist/Zilla.pm line 387.

It didn't let me build the distribution. So I added copyright holder and year detail as per the pod.
It is now happy.

Many Thanks.
Best Regards,
Mohammad S Anwar
